### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ factopy
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gersolar/factopy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![GNU/AGPL License](http://www.gnu.org/graphics/agplv3-88x31.png)](https://github.com/gersolar/factopy/blob/master/GNU-AGPL-3.0.txt) [![Build Status](https://travis-ci.org/gersolar/factopy.png?branch=master)](https://travis-ci.org/gersolar/factopy) [![Coverage Status](https://coveralls.io/repos/gersolar/factopy/badge.png)](https://coveralls.io/r/gersolar/factopy) [![Code Health](https://landscape.io/github/gersolar/factopy/master/landscape.png)](https://landscape.io/github/gersolar/factopy/master) [![django packages badge](https://pypip.in/d/factopy/badge.png)](https://www.djangopackages.com/packages/p/factopy/)
-[![Supported Python versions](https://pypip.in/py_versions/factopy/badge.svg)](https://pypi.python.org/pypi/factopy/) [![Stories in Ready](https://badge.waffle.io/gersolar/factopy.png?label=ready&title=Ready)](https://waffle.io/gersolar/factopy)
+[![GNU/AGPL License](http://www.gnu.org/graphics/agplv3-88x31.png)](https://github.com/gersolar/factopy/blob/master/GNU-AGPL-3.0.txt) [![Build Status](https://travis-ci.org/gersolar/factopy.png?branch=master)](https://travis-ci.org/gersolar/factopy) [![Coverage Status](https://coveralls.io/repos/gersolar/factopy/badge.png)](https://coveralls.io/r/gersolar/factopy) [![Code Health](https://landscape.io/github/gersolar/factopy/master/landscape.png)](https://landscape.io/github/gersolar/factopy/master) [![django packages badge](https://img.shields.io/pypi/dm/factopy.svg)](https://www.djangopackages.com/packages/p/factopy/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/factopy.svg)](https://pypi.python.org/pypi/factopy/) [![Stories in Ready](https://badge.waffle.io/gersolar/factopy.png?label=ready&title=Ready)](https://waffle.io/gersolar/factopy)
 
 **factopy** is a python framework and provides abstract classes for a high performance computing cluster based in a pipe and filter architecture.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20factopy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `factopy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.